### PR TITLE
Permit ParamType for run()

### DIFF
--- a/src/arrows.js
+++ b/src/arrows.js
@@ -113,8 +113,8 @@ class Arrow {
     }
 
     run() {
-        if (!(this.type.arg instanceof TopType)) {
-            throw new Error("Cannot run an arrow that takes arguments");
+        if (!((this.type.arg instanceof TopType) || (this.type.arg instanceof ParamType))) {
+            throw new Error("Cannot run an arrow that takes arguments (expected " + this.type.arg + ")");
         }
 
         let p = new Progress(true);


### PR DESCRIPTION
Currently, the `.run()` helper is only allowed if `this.type.arg instanceof TopType`, but I think it should apply if `this.type.arg instanceof ParamType` as well.

Consider (run in nodejs with my setup, but transfers to standard Arrows as well I believe; compressed & commented as applicable):
```
> new LiftedArrow((/* @arrow :: _ ~> _ */) => {}).run()
Progress { canEmit: true, cancelers: {}, observers: [] }
 // OK! We can run with Top~>Top

> new LiftedArrow((/* @arrow :: _ ~> _ */) => {}).fanout().run()
Error: Cannot run an arrow that takes arguments (expected '3)
// Fanout creates a ParamType that can no longer be called with run,
// even though it's still specified as Top

> new LiftedArrow((/* @arrow :: _ ~> String */) => "mystring").fanout().run()
Error: Cannot run an arrow that takes arguments (expected '5)
// Fanout still confuses it - why shouldn't I be able to run() this?

> new LiftedArrow((/* @arrow :: 'a ~> _ */) => {}).run();
Error: Cannot run an arrow that takes arguments (expected '1)
// contrived example, but should I not be able to run() this?
```

Feel free to reject this if there's a reason an unresolved `ParamType` couldn't be substituted with `null` in a `run()`...

@tianzhao fyi